### PR TITLE
fix vertical alignment of links

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,17 +20,14 @@ body {
 
 a {
   color: #0468bf;
-  max-width: 100%;
   white-space: nowrap;
-  display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 a:visited {
   color: #05aff2;
 }
 p {
   margin: 0.5em 0;
+  text-overflow: ellipsis;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/index.css
+++ b/src/index.css
@@ -27,7 +27,6 @@ a:visited {
 }
 p {
   margin: 0.5em 0;
-  text-overflow: ellipsis;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Hi Colin,

`display: inline-block` ruins the vertical alignment of links. It's needed for `text-overflow: ellipsis` to work properly, but imho, it's not necessary here.

This PR removes the `display` property and some other unnecessary properties.

Before (with `inline-block`):

![localhost_5173__latest=true](https://github.com/user-attachments/assets/bdf7039f-6b11-427d-8cec-36feb1de9d16)

After (without `inline-block`):

![localhost_5173__latest=true (1)](https://github.com/user-attachments/assets/2ed61558-1c31-4fed-9d73-2a62cc98a764)
