### PR TITLE
Regenerate README.md to include CodeXomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ their tools. They went through the effort to write it up, cite these tools!!
   [(img)](https://cmdcolin.github.io/awesome-genome-visualization/biodalliance.png)
 - [Celera genome browser](https://www.csee.umbc.edu/~turner/presentations/bvw2002/sld009.htm)
   [(img)](https://cmdcolin.github.io/awesome-genome-visualization/celera.jpeg)
+- [CodeXomics](https://scilence2022.github.io/CodeXomics/) (AI-native genome
+  browser: conversational agents drive the view and run BLAST, primer design,
+  and structure lookups; MCP server and plugin architecture included)
+  [(img)](https://cmdcolin.github.io/awesome-genome-visualization/codexomics.png)
 - [Ensembl genome browser](https://useast.ensembl.org/Homo_sapiens/Location/View?r=17:63992802-64038237)
   [(img)](https://cmdcolin.github.io/awesome-genome-visualization/ensembl.png)
 - [Ensembl genome browser 2020 edition](http://2020.ensembl.org/)


### PR DESCRIPTION
## Summary
- CodeXomics was added to `TOOLS.json` in #66 and merged, but `README.md` (which is generated from `TOOLS.json`) wasn't regenerated afterwards, so the entry is missing from the rendered list.
- This PR regenerates `README.md` via `node --experimental-strip-types scripts/gen_readme.ts` followed by `prettier --write`, matching the existing formatting exactly. The only content change is the 4-line CodeXomics entry under the "General" category.

## Test plan
- [x] Diffed the regenerated README against the committed one — only the new CodeXomics entry differs, no unrelated reformatting.